### PR TITLE
Add RectangleIterator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(grid_map_proc
   src/grid_map_path_planning.cpp
   src/grid_map_polygon_tools.cpp
   src/grid_map_transforms.cpp
+  src/rectangle_iterator.cpp
 )
 
 ## Add cmake target dependencies of the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(grid_map_proc)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,16 +18,19 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
+find_package(Eigen3 REQUIRED)
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES grid_map_proc
   CATKIN_DEPENDS eigen_conversions geometry_msgs grid_map_core grid_map_msgs grid_map_ros roscpp tf
-#  DEPENDS system_lib
+  DEPENDS EIGEN3
 )
 
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library

--- a/include/grid_map_proc/rectangle_iterator.h
+++ b/include/grid_map_proc/rectangle_iterator.h
@@ -6,6 +6,7 @@
 #include <grid_map_core/TypeDefs.hpp>
 
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 
 #include <iterator>
 #include <memory>
@@ -39,7 +40,6 @@ private:
   bool nextStep();
   bool isInside();
 
-  grid_map::Polygon polygon_;
   grid_map::Vector map_offset_;
   grid_map::Position map_position_;
   double map_resolution_;
@@ -49,6 +49,11 @@ private:
   grid_map::Index start_index_;
   grid_map::Index end_index_;
   grid_map::Index index_;
+
+  double x_length_half_;
+  double y_length_half_;
+
+  Eigen::Isometry2d rectangle_transform_;
 
   bool past_end_;
 };

--- a/include/grid_map_proc/rectangle_iterator.h
+++ b/include/grid_map_proc/rectangle_iterator.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <grid_map_core/GridMap.hpp>
+#include <grid_map_core/iterators/SubmapIterator.hpp>
+#include <grid_map_core/Polygon.hpp>
+#include <grid_map_core/TypeDefs.hpp>
+
+#include <iterator>
+#include <memory>
+
+namespace grid_map_proc
+{
+class RectangleIterator
+{
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = grid_map::Index;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;
+
+  RectangleIterator(const grid_map::GridMap& map, const grid_map::Polygon& rectangle_polygon);
+
+  RectangleIterator& operator++();
+
+  bool pastEnd() const;
+
+  reference operator*();
+  pointer operator->();
+
+  bool operator==(const RectangleIterator& other);
+  bool operator!=(const RectangleIterator& other);
+
+private:
+  bool nextStep();
+  bool isInside();
+
+  grid_map::Polygon polygon_;
+  grid_map::Vector map_offset_;
+  grid_map::Position map_position_;
+  double map_resolution_;
+  grid_map::Size map_buffer_size_;
+  grid_map::Index map_buffer_start_index_;
+
+  grid_map::Index start_index_;
+  grid_map::Index end_index_;
+  grid_map::Index index_;
+
+  bool past_end_;
+};
+
+}  // namespace grid_map_proc

--- a/include/grid_map_proc/rectangle_iterator.h
+++ b/include/grid_map_proc/rectangle_iterator.h
@@ -5,6 +5,8 @@
 #include <grid_map_core/Polygon.hpp>
 #include <grid_map_core/TypeDefs.hpp>
 
+#include <Eigen/Core>
+
 #include <iterator>
 #include <memory>
 

--- a/package.xml
+++ b/package.xml
@@ -40,6 +40,8 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>eigen</build_depend>
   <build_depend>eigen_conversions</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>grid_map_core</build_depend>
@@ -48,6 +50,7 @@
   <build_depend>nav_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
+  <run_depend>eigen</run_depend>
   <run_depend>eigen_conversions</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>grid_map_core</run_depend>

--- a/src/rectangle_iterator.cpp
+++ b/src/rectangle_iterator.cpp
@@ -54,8 +54,6 @@ RectangleIterator::RectangleIterator(const grid_map::GridMap& map, const grid_ma
   start_index_ = get_index(max_x, max_y);
   end_index_ = get_index(min_x, min_y);
 
-  index_ = start_index_;
-
   const grid_map::Vector map_center = 0.5 * map.getLength();
   map_offset_ = (map_center.array() - 0.5 * map.getResolution()).matrix();
 
@@ -63,6 +61,10 @@ RectangleIterator::RectangleIterator(const grid_map::GridMap& map, const grid_ma
   map_resolution_ = map.getResolution();
   map_buffer_size_ = map.getSize();
   map_buffer_start_index_ = map.getStartIndex();
+
+  // Move to first valid position
+  index_ = start_index_.array() - 1;
+  ++(*this);
 }
 
 RectangleIterator& RectangleIterator::operator++()

--- a/src/rectangle_iterator.cpp
+++ b/src/rectangle_iterator.cpp
@@ -1,0 +1,131 @@
+#include "grid_map_proc/rectangle_iterator.h"
+
+#include <ros/console.h>
+
+#include <grid_map_core/GridMapMath.hpp>
+#include <grid_map_core/SubmapGeometry.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace grid_map_proc
+{
+RectangleIterator::RectangleIterator(const grid_map::GridMap& map, const grid_map::Polygon& rectangle_polygon)
+  : polygon_{ rectangle_polygon }, past_end_{ false }
+{
+  const std::vector<grid_map::Position>& vertices = polygon_.getVertices();
+  if (vertices.size() != 4U)
+  {
+    std::string error{ "RectangleIterator needs 4 point polygone, got size " + std::to_string(vertices.size()) };
+    ROS_FATAL_STREAM(error);
+    throw std::domain_error(error);
+  }
+
+  const grid_map::Position& front_point = vertices.front();
+  double min_x = front_point.x();
+  double max_x = front_point.x();
+
+  double min_y = front_point.y();
+  double max_y = front_point.y();
+
+  for (uint8_t i = 1; i < 4U; ++i)
+  {
+    const grid_map::Position& point = vertices.at(i);
+    min_x = std::min(min_x, point.x());
+    max_x = std::max(max_x, point.x());
+
+    min_y = std::min(min_y, point.y());
+    max_y = std::max(max_y, point.y());
+  }
+
+  const auto get_index = [&map](const double x, const double y) -> grid_map::Index {
+    grid_map::Position position{ x, y };
+    position = map.getClosestPositionInMap(position);
+
+    grid_map::Index index;
+    map.getIndex(position, index);
+
+    return index;
+  };
+
+  // Position coordinates and index directions are flipped
+  start_index_ = get_index(max_x, max_y);
+  end_index_ = get_index(min_x, min_y);
+
+  index_ = start_index_;
+
+  const grid_map::Vector map_center = 0.5 * map.getLength();
+  map_offset_ = (map_center.array() - 0.5 * map.getResolution()).matrix();
+
+  map_position_ = map.getPosition();
+  map_resolution_ = map.getResolution();
+  map_buffer_size_ = map.getSize();
+  map_buffer_start_index_ = map.getStartIndex();
+}
+
+RectangleIterator& RectangleIterator::operator++()
+{
+  while (nextStep())
+  {
+    if (isInside())
+    {
+      break;
+    }
+  }
+
+  return *this;
+}
+
+bool RectangleIterator::nextStep()
+{
+  if (index_.x() != end_index_.x())
+  {
+    ++index_.x();
+  }
+  else
+  {
+    index_.x() = start_index_.x();
+    ++index_.y();
+  }
+
+  past_end_ = index_.y() > end_index_.y();
+  return !past_end_;
+}
+
+bool RectangleIterator::isInside()
+{
+  const grid_map::Index unwrappedIndex =
+      grid_map::getIndexFromBufferIndex(index_, map_buffer_size_, map_buffer_start_index_);
+  const grid_map::Vector index_vector{ -unwrappedIndex.x(), -unwrappedIndex.y() };
+
+  const grid_map::Position position = map_position_ + map_offset_ + map_resolution_ * index_vector;
+
+  return polygon_.isInside(position);
+}
+
+bool RectangleIterator::pastEnd() const
+{
+  return past_end_;
+}
+
+RectangleIterator::reference RectangleIterator::operator*()
+{
+  return index_;
+}
+RectangleIterator::pointer RectangleIterator::operator->()
+{
+  return &index_;
+}
+
+bool RectangleIterator::operator==(const RectangleIterator& other)
+{
+  return index_.x() == other.index_.x() && index_.y() == other.index_.y();
+}
+bool RectangleIterator::operator!=(const RectangleIterator& other)
+{
+  return index_.x() != other.index_.x() || index_.y() != other.index_.y();
+}
+
+}  // namespace grid_map_proc

--- a/src/rectangle_iterator.cpp
+++ b/src/rectangle_iterator.cpp
@@ -18,7 +18,7 @@ RectangleIterator::RectangleIterator(const grid_map::GridMap& map, const grid_ma
   const std::vector<grid_map::Position>& vertices = polygon_.getVertices();
   if (vertices.size() != 4U)
   {
-    std::string error{ "RectangleIterator needs 4 point polygone, got size " + std::to_string(vertices.size()) };
+    std::string error{ "RectangleIterator needs 4 point polygon, got size " + std::to_string(vertices.size()) };
     ROS_FATAL_STREAM(error);
     throw std::domain_error(error);
   }


### PR DESCRIPTION
Adds `RectangleIterator` class which is higher performance than the default grid map `PolygonIterator`.

It actually currently would also work with Polygons (if the size check at construction is removed).

Also changed the compiler options to use and enforce C++14