### PR TITLE
Add catch2 tests for RectangleIterator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+  catch_ros
   eigen_conversions
   geometry_msgs
   grid_map_core
@@ -57,6 +58,8 @@ add_dependencies(grid_map_proc ${catkin_EXPORTED_TARGETS})
 target_link_libraries(grid_map_proc
   ${catkin_LIBRARIES}
 )
+
+add_subdirectory(test)
 
 #############
 ## Install ##

--- a/package.xml
+++ b/package.xml
@@ -41,6 +41,7 @@
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>catch_ros</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>eigen_conversions</build_depend>
   <build_depend>geometry_msgs</build_depend>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+file(GLOB SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
+
+catch_add_test(
+  ${PROJECT_NAME}_tests
+  ${SOURCES}
+)
+target_link_libraries(
+  ${PROJECT_NAME}_tests
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+)

--- a/test/test_rectangle_iterator.cpp
+++ b/test/test_rectangle_iterator.cpp
@@ -1,0 +1,152 @@
+#include "grid_map_proc/rectangle_iterator.h"
+
+#include <catch_ros/catch.hpp>
+#include <grid_map_core/GridMap.hpp>
+#include <grid_map_core/Polygon.hpp>
+#include <ros/console.h>
+
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+using namespace grid_map_proc;
+
+// Eigen objects can't be easily compared so std::find doesn't work
+static bool contains(const std::vector<grid_map::Index>& indices, const grid_map::Index& index)
+{
+  for (const auto& index_in_vector : indices)
+  {
+    if (index.x() == index_in_vector.x() && index.y() == index_in_vector.y())
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+TEST_CASE("constructor", "RectangleTterator")
+{
+  grid_map::Position zero_pos;
+  grid_map::Polygon polygon({ zero_pos, zero_pos, zero_pos, zero_pos });
+  REQUIRE_NOTHROW(RectangleIterator({}, polygon));
+}
+
+TEST_CASE("even_size", "RectangleTterator")
+{
+  const grid_map::Length length{ 6.0, 8.0 };
+  const double resolution = 1.0;
+
+  grid_map::GridMap map;
+  map.setGeometry(length, resolution);
+  std::vector<grid_map::Position> vertices{ { 2.1, 2.6 }, { 2.1, -2.6 }, { -2.1, -2.6 }, { -2.1, 2.6 } };
+
+  std::vector<grid_map::Index> indices;
+  for (grid_map_proc::RectangleIterator it(map, { vertices }); !it.pastEnd(); ++it)
+  {
+    indices.push_back(*it);
+  }
+
+  REQUIRE(indices.size() == 24);
+
+  // for (const auto& index_in_vector : indices)
+  // {
+  //   ROS_ERROR_STREAM("index: " << index_in_vector.transpose());
+  // }
+
+  for (size_t x = 1; x < 5; ++x)
+  {
+    for (size_t y = 1; y < 6; ++y)
+    {
+      REQUIRE(contains(indices, { x, y }));
+    }
+  }
+
+  for (size_t x = 0; x < 6; ++x)
+  {
+    REQUIRE_FALSE(contains(indices, { x, 0 }));
+    REQUIRE_FALSE(contains(indices, { x, 7 }));
+  }
+
+  for (size_t y = 0; y < 8; ++y)
+  {
+    REQUIRE_FALSE(contains(indices, { 0, y }));
+    REQUIRE_FALSE(contains(indices, { 5, y }));
+  }
+}
+
+TEST_CASE("odd_size", "RectangleTterator")
+{
+  const grid_map::Length length{ 5.0, 7.0 };
+  const double resolution = 1.0;
+
+  grid_map::GridMap map;
+  map.setGeometry(length, resolution);
+  std::vector<grid_map::Position> vertices{ { 2.1, 2.6 }, { 2.1, -2.6 }, { -2.1, -2.6 }, { -2.1, 2.6 } };
+
+  std::vector<grid_map::Index> indices;
+  for (grid_map_proc::RectangleIterator it(map, { vertices }); !it.pastEnd(); ++it)
+  {
+    indices.push_back(*it);
+  }
+
+  REQUIRE(indices.size() == 25);
+
+  // for (const auto& index_in_vector : indices)
+  // {
+  //   ROS_ERROR_STREAM("index: " << index_in_vector.transpose());
+  // }
+
+  for (size_t x = 0; x < 4; ++x)
+  {
+    for (size_t y = 1; y < 5; ++y)
+    {
+      REQUIRE(contains(indices, { x, y }));
+    }
+  }
+
+  for (size_t x = 0; x < 4; ++x)
+  {
+    REQUIRE_FALSE(contains(indices, { x, 0 }));
+    REQUIRE_FALSE(contains(indices, { x, 6 }));
+  }
+}
+
+TEST_CASE("45_degrees", "RectangleTterator")
+{
+  const grid_map::Length length{ 6.0, 8.0 };
+  const double resolution = 1.0;
+
+  grid_map::GridMap map;
+  map.setGeometry(length, resolution);
+  const double value = 2.01;
+  std::vector<grid_map::Position> vertices{ { value, 0.0 }, { 0.0, -value }, { -value, 0.0 }, { 0.0, value } };
+
+  std::vector<grid_map::Index> indices;
+  for (grid_map_proc::RectangleIterator it(map, { vertices }); !it.pastEnd(); ++it)
+  {
+    indices.push_back(*it);
+  }
+
+  REQUIRE(indices.size() == 12);
+
+  REQUIRE(contains(indices, { 1, 3 }));
+  REQUIRE(contains(indices, { 1, 4 }));
+
+  REQUIRE(contains(indices, { 2, 2 }));
+  REQUIRE(contains(indices, { 2, 3 }));
+  REQUIRE(contains(indices, { 2, 4 }));
+  REQUIRE(contains(indices, { 2, 5 }));
+
+  REQUIRE(contains(indices, { 3, 2 }));
+  REQUIRE(contains(indices, { 3, 3 }));
+  REQUIRE(contains(indices, { 3, 4 }));
+  REQUIRE(contains(indices, { 3, 5 }));
+
+  REQUIRE(contains(indices, { 4, 3 }));
+  REQUIRE(contains(indices, { 4, 4 }));
+
+  REQUIRE_FALSE(contains(indices, { 1, 2 }));
+  REQUIRE_FALSE(contains(indices, { 1, 5 }));
+  REQUIRE_FALSE(contains(indices, { 4, 2 }));
+  REQUIRE_FALSE(contains(indices, { 4, 5 }));
+}


### PR DESCRIPTION
Add some catch2 tests for RectangleIterator.

I had some suspicions that the index is sometimes off, but seems all alright. Might as well just keep the tests.

Adds a dependency to `catch_ros`, besides that doesn't do anything unless compiled with the test flag.