### PR TITLE
feat: add soft inflation layer support and catch_ros-based unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(grid_map_proc)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(CATCH_ROS "")
+if(CATKIN_ENABLE_TESTING)
+  set(CATCH_ROS catch_ros)
+endif()
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
@@ -16,21 +21,24 @@ find_package(catkin REQUIRED COMPONENTS
   nav_msgs
   roscpp
   tf
+  ${CATCH_ROS}
 )
 
 find_package(Eigen3 REQUIRED)
+find_package(OpenCV REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES grid_map_proc
   CATKIN_DEPENDS eigen_conversions geometry_msgs grid_map_core grid_map_msgs grid_map_ros roscpp tf
-  DEPENDS EIGEN3
+  DEPENDS EIGEN3 OpenCV
 )
 
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library
@@ -56,6 +64,7 @@ add_dependencies(grid_map_proc ${catkin_EXPORTED_TARGETS})
 ## Specify libraries to link a library or executable target against
 target_link_libraries(grid_map_proc
   ${catkin_LIBRARIES}
+  ${OpenCV_LIBRARIES}
 )
 
 #############
@@ -97,11 +106,6 @@ install(DIRECTORY include/${PROJECT_NAME}/
 ## Testing ##
 #############
 
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_grid_map_proc.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+if(CATKIN_ENABLE_TESTING)
+  add_subdirectory(test)
+endif()

--- a/package.xml
+++ b/package.xml
@@ -47,6 +47,7 @@
   <build_depend>grid_map_core</build_depend>
   <build_depend>grid_map_msgs</build_depend>
   <build_depend>grid_map_ros</build_depend>
+  <build_depend>libopencv-dev</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
@@ -56,10 +57,12 @@
   <run_depend>grid_map_core</run_depend>
   <run_depend>grid_map_msgs</run_depend>
   <run_depend>grid_map_ros</run_depend>
+  <run_depend>libopencv-dev</run_depend>
   <run_depend>nav_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
 
+  <test_depend>catch_ros</test_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/src/grid_map_transforms.cpp
+++ b/src/grid_map_transforms.cpp
@@ -878,8 +878,6 @@ namespace grid_map_transforms{
     ensureMatSize(soft_inflated_mat_, ds_size_y, ds_size_x, CV_32FC1);
     cv::distanceTransform(map_mat_, soft_inflated_mat_, cv::DIST_L2, 3);
 
-    float* soft_inflated_mat_p = soft_inflated_mat_.ptr<float>();
-
     // Map distance to 0-OBSTACLE_VALUE cost
     const float max_dist = (inflation_radius_map_cells > 0.0f) ? inflation_radius_map_cells :
                                                                  static_cast<float>(std::min(size_x, size_y)) / 2.0f;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,13 @@
+
+file(GLOB SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
+
+catch_add_test(
+  ${PROJECT_NAME}_tests
+  ${SOURCES}
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_tests
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+)

--- a/test/test_inflation_layer_provider.cpp
+++ b/test/test_inflation_layer_provider.cpp
@@ -1,0 +1,300 @@
+#include <catch_ros/catch.hpp>
+#include <grid_map_proc/grid_map_transforms.h>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <iostream>
+#include <cmath>
+
+using namespace grid_map;
+using namespace grid_map_transforms;
+
+grid_map::GridMap createTestMap()
+{
+  using namespace grid_map;
+  GridMap map({ "occupancy" });
+  map.setGeometry(Length(1.5, 1.0), 0.01);  // 150 x 100 cells
+  map["occupancy"].setZero();
+
+  // Add rectangle obstacle
+  for (int x = 30; x < 40; ++x)
+    for (int y = 30; y < 70; ++y)
+      map["occupancy"](x, y) = InflatedLayerProvider::OBSTACLE_VALUE;
+
+  // Add circular obstacle
+  for (int x = 60; x < 80; ++x)
+    for (int y = 40; y < 60; ++y)
+      if (std::hypot(x - 70, y - 50) <= 10)
+        map["occupancy"](x, y) = InflatedLayerProvider::OBSTACLE_VALUE;
+
+  // Medium-cost zone (20.0)
+  for (int x = 80; x < 100; ++x)
+    for (int y = 70; y < 90; ++y)
+      map["occupancy"](x, y) = InflatedLayerProvider::OBSTACLE_VALUE * 0.2f;
+
+  // High-cost zone (120.0)
+  for (int x = 90; x < 110; ++x)
+    for (int y = 40; y < 60; ++y)
+      map["occupancy"](x, y) = InflatedLayerProvider::OBSTACLE_VALUE * 1.2f;
+
+  return map;
+}
+
+template <typename SetupFn, typename BenchmarkFn>
+double benchmarkFunction(const SetupFn& setup, const BenchmarkFn& run)
+{
+  constexpr int NUM_ITERATIONS = 1000;
+  double total_us = 0.0;
+  for (int i = 0; i < NUM_ITERATIONS; ++i)
+  {
+    auto context = setup();  // construct per-iteration input
+    auto start = std::chrono::high_resolution_clock::now();
+    run(context);  // run benchmark on it
+    auto end = std::chrono::high_resolution_clock::now();
+    total_us += std::chrono::duration<double, std::micro>(end - start).count();
+  }
+  return total_us / NUM_ITERATIONS;
+}
+
+constexpr float BINARY_INFLATION_RADIUS = 20.0f;
+constexpr float SOFT_INFLATION_RADIUS = 20.0f;
+
+TEST_CASE("Visual test: inflation layer provider", "[manual][visual]")
+{
+  InflatedLayerProvider inf_layer_provider;
+  GridMap map = createTestMap();
+
+  const int size_x = map.getSize()(0);  // cols
+  const int size_y = map.getSize()(1);  // rows
+
+  // Inflate layers
+  constexpr int downsample_factor = 1;
+  REQUIRE(inf_layer_provider.addSoftInflatedLayer(map, SOFT_INFLATION_RADIUS, "occupancy", "occupancy_soft_inflated",
+                                                  downsample_factor));
+  REQUIRE(inf_layer_provider.addInflatedLayer(map, BINARY_INFLATION_RADIUS, "occupancy", "occupancy_inflated",
+                                              cv::MORPH_RECT));
+
+  const auto& soft_data = map["occupancy_soft_inflated"];
+  const auto& binary_data = map["occupancy_inflated"];
+
+  // Analyze counts
+  int obstacle_nonzero_count = 0;
+  int soft_nonzero_count = 0;
+  int binary_nonzero_count = 0;
+  bool all_preserved = true;
+
+  for (int x = 0; x < size_x; ++x)
+  {
+    for (int y = 0; y < size_y; ++y)
+    {
+      float occ_val = map["occupancy"](x, y);
+      float soft_val = soft_data(x, y);
+      float binary_val = binary_data(x, y);
+
+      if (occ_val != 0.0f)
+        obstacle_nonzero_count++;
+
+      if (binary_val != 0.0f)
+        binary_nonzero_count++;
+
+      if (soft_val != 0.0f)
+        soft_nonzero_count++;
+
+      if (occ_val != 0.0f)
+      {
+        if (!(std::abs(soft_val - occ_val) < 1e-3f && std::abs(binary_val - occ_val) < 1e-3f))
+          all_preserved = false;
+      }
+    }
+  }
+
+  // Preserve obstacle and medium-cost values
+  REQUIRE(all_preserved);
+
+  // The inflated layers must have more nonzero cells than the occupancy alone
+  REQUIRE(soft_nonzero_count > obstacle_nonzero_count);
+  REQUIRE(binary_nonzero_count > obstacle_nonzero_count);
+
+  // Visualize the layers for debugging:
+
+  cv::Mat occ_img(size_y, size_x, CV_8UC1);
+  for (int x = 0; x < size_x; ++x)
+    for (int y = 0; y < size_y; ++y)
+      occ_img.at<uchar>(y, x) = static_cast<uchar>(map["occupancy"](x, y));
+
+  cv::Mat soft_img(size_y, size_x, CV_8UC1);
+  cv::Mat binary_img(size_y, size_x, CV_8UC1);
+  cv::Mat combined_img(size_y, size_x, CV_8UC1);
+
+  for (int x = 0; x < size_x; ++x)
+  {
+    for (int y = 0; y < size_y; ++y)
+    {
+      soft_img.at<uchar>(y, x) = static_cast<uchar>(soft_data(x, y));
+      binary_img.at<uchar>(y, x) = static_cast<uchar>(binary_data(x, y));
+      float sum = map["occupancy"](x, y) + soft_data(x, y) + binary_data(x, y);
+      combined_img.at<uchar>(y, x) = static_cast<uchar>(std::min(sum * 255.0f / 300.0f, 255.0f));
+    }
+  }
+
+  // Label each image
+  const int font = cv::FONT_HERSHEY_SIMPLEX;
+  const double scale = 0.4;
+  const int thickness = 1;
+  const cv::Scalar color = 255;
+
+  cv::putText(occ_img, "Occupancy", { 5, 15 }, font, scale, color, thickness);
+  cv::putText(binary_img, "Binary Inflated", { 5, 15 }, font, scale, color, thickness);
+  cv::putText(soft_img, "Soft Inflated", { 5, 15 }, font, scale, color, thickness);
+  cv::putText(combined_img, "Combined (Gray)", { 5, 15 }, font, scale, color, thickness);
+
+  // Combine views
+  cv::Mat row1, row2, all;
+  cv::hconcat(occ_img, binary_img, row1);
+  cv::hconcat(soft_img, combined_img, row2);
+  cv::vconcat(row1, row2, all);
+
+  // Save to file (e.g., in /tmp or package-relative path)
+  std::string out_path = "/tmp/inflation_layers_output.png";
+  cv::imwrite(out_path, all);
+  std::cout << "Saved visualization to: " << out_path << std::endl;
+
+  // Optional: Show images for visual inspection if enabled via ENV
+  const char* show_env = std::getenv("SHOW_INFLATION_VISUALS");
+  if (show_env && std::string(show_env) == "1")
+  {
+    cv::imshow("All Maps (Occupancy | Binary | Soft | Combined)", all);
+    cv::waitKey(0);
+  }
+
+  SUCCEED("Visual inflation layers rendered.");
+}
+
+TEST_CASE("binary inflation kernel benchmark", "[benchmark]")
+{
+  InflatedLayerProvider inf_layer_provider;
+  GridMap map = createTestMap();
+
+  SECTION("MORPH_RECT")
+  {
+    double avg = benchmarkFunction(  //
+        [&]() { return map; },
+        [&](GridMap& temp) {
+          inf_layer_provider.addInflatedLayer(temp, BINARY_INFLATION_RADIUS, "occupancy", "inflated", cv::MORPH_RECT);
+        });
+    std::cout << "[Benchmark] Binary Inflation RECT    Avg: " << avg << " µs\n";
+  }
+
+  SECTION("MORPH_ELLIPSE")
+  {
+    double avg = benchmarkFunction(  //
+        [&]() { return map; },
+        [&](GridMap& temp) {
+          inf_layer_provider.addInflatedLayer(temp, BINARY_INFLATION_RADIUS, "occupancy", "inflated",
+                                              cv::MORPH_ELLIPSE);
+        });
+    std::cout << "[Benchmark] Binary Inflation ELLIPSE Avg: " << avg << " µs\n";
+  }
+
+  SUCCEED("Inflation kernel benchmarking completed.");
+}
+
+TEST_CASE("Benchmark: Soft Inflation Decay Types (with Downsampling)", "[benchmark]")
+{
+  const GridMap map = createTestMap();
+  InflatedLayerProvider inf_layer_provider;
+
+  auto printBenchmarkResult = [](const std::string& decay, int ds, double avg) {
+    std::cout << std::left << "[Benchmark] Soft Inflation " << std::setw(12) << decay << "DS=" << ds
+              << " Avg: " << std::fixed << std::setprecision(3) << avg << " µs\n";
+  };
+
+  SECTION("Exponential Decay - Downsample x1")
+  {
+    double avg =
+        benchmarkFunction([&]() { return map; },
+                          [&](GridMap& temp) {
+                            inf_layer_provider.addSoftInflatedLayer(temp, SOFT_INFLATION_RADIUS, "occupancy", "soft", 1,
+                                                                    InflatedLayerProvider::DecayType::Exponential);
+                          });
+    printBenchmarkResult("Exponential", 1, avg);
+  }
+
+  SECTION("Quadratic Decay - Downsample x1")
+  {
+    double avg =
+        benchmarkFunction([&]() { return map; },
+                          [&](GridMap& temp) {
+                            inf_layer_provider.addSoftInflatedLayer(temp, SOFT_INFLATION_RADIUS, "occupancy", "soft", 1,
+                                                                    InflatedLayerProvider::DecayType::Quadratic);
+                          });
+    printBenchmarkResult("Quadratic", 1, avg);
+  }
+
+  SECTION("Linear Decay - Downsample x1")
+  {
+    double avg =
+        benchmarkFunction([&]() { return map; },
+                          [&](GridMap& temp) {
+                            inf_layer_provider.addSoftInflatedLayer(temp, SOFT_INFLATION_RADIUS, "occupancy", "soft", 1,
+                                                                    InflatedLayerProvider::DecayType::Linear);
+                          });
+    printBenchmarkResult("Linear", 1, avg);
+  }
+
+  SECTION("Binary Decay - Downsample x1")
+  {
+    double avg =
+        benchmarkFunction([&]() { return map; },
+                          [&](GridMap& temp) {
+                            inf_layer_provider.addSoftInflatedLayer(temp, SOFT_INFLATION_RADIUS, "occupancy", "soft", 1,
+                                                                    InflatedLayerProvider::DecayType::Binary);
+                          });
+    printBenchmarkResult("Binary", 1, avg);
+  }
+
+  SECTION("Exponential Decay - Downsample x2")
+  {
+    double avg =
+        benchmarkFunction([&]() { return map; },
+                          [&](GridMap& temp) {
+                            inf_layer_provider.addSoftInflatedLayer(temp, SOFT_INFLATION_RADIUS, "occupancy", "soft", 2,
+                                                                    InflatedLayerProvider::DecayType::Exponential);
+                          });
+    printBenchmarkResult("Exponential", 2, avg);
+  }
+
+  SECTION("Quadratic Decay - Downsample x2")
+  {
+    double avg =
+        benchmarkFunction([&]() { return map; },
+                          [&](GridMap& temp) {
+                            inf_layer_provider.addSoftInflatedLayer(temp, SOFT_INFLATION_RADIUS, "occupancy", "soft", 2,
+                                                                    InflatedLayerProvider::DecayType::Quadratic);
+                          });
+    printBenchmarkResult("Quadratic", 2, avg);
+  }
+
+  SECTION("Linear Decay - Downsample x2")
+  {
+    double avg =
+        benchmarkFunction([&]() { return map; },
+                          [&](GridMap& temp) {
+                            inf_layer_provider.addSoftInflatedLayer(temp, SOFT_INFLATION_RADIUS, "occupancy", "soft", 2,
+                                                                    InflatedLayerProvider::DecayType::Linear);
+                          });
+    printBenchmarkResult("Linear", 2, avg);
+  }
+
+  SECTION("Binary Decay - Downsample x2")
+  {
+    double avg =
+        benchmarkFunction([&]() { return map; },
+                          [&](GridMap& temp) {
+                            inf_layer_provider.addSoftInflatedLayer(temp, SOFT_INFLATION_RADIUS, "occupancy", "soft", 2,
+                                                                    InflatedLayerProvider::DecayType::Binary);
+                          });
+    printBenchmarkResult("Binary", 2, avg);
+  }
+
+  SUCCEED();
+}


### PR DESCRIPTION
- Added InflatedLayerProvider::addSoftInflatedLayer() to generate soft inflated costmaps using OpenCV's distance transform.
- Ensured that both soft and binary inflation preserve original non-zero occupancy values (e.g., 20.0, 100.0, 120.0).
- Integrated OpenCV as a required dependency in both CMakeLists.txt and package.xml.
- Enabled unit testing with catch_ros, conditionally activated via CATKIN_ENABLE_TESTING.
- Added a structured unit test (test_inflation_layer_provider.cpp) to:
  - Validate inflation correctness (value preservation and inflation area growth).
  - Save visual output to /tmp/inflation_layers_output.png.
  - Optionally display the image if SHOW_INFLATION_VISUALS=1 is set.